### PR TITLE
Allowed configurable css link for stylesheets

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -137,6 +137,7 @@ export default class App extends React.Component {
                 showPopup: this.state.showPopup,
                 adminUrl: this.props.adminUrl,
                 appVersion: this.props.appVersion,
+                stylesUrl: this.props.stylesUrl,
                 searchIndex: this.state.searchIndex,
                 indexComplete: this.state.indexComplete,
                 searchValue: this.state.searchValue,

--- a/src/App.js
+++ b/src/App.js
@@ -136,7 +136,6 @@ export default class App extends React.Component {
                 page: 'search',
                 showPopup: this.state.showPopup,
                 adminUrl: this.props.adminUrl,
-                appVersion: this.props.appVersion,
                 stylesUrl: this.props.stylesUrl,
                 searchIndex: this.state.searchIndex,
                 indexComplete: this.state.indexComplete,

--- a/src/components/PopupModal.js
+++ b/src/components/PopupModal.js
@@ -4,7 +4,6 @@ import {ReactComponent as SearchIcon} from '../icons/search.svg';
 import {ReactComponent as ClearIcon} from '../icons/clear.svg';
 import {ReactComponent as CircleAnimated} from '../icons/circle-anim.svg';
 import {useContext, useEffect, useMemo, useRef, useState} from 'react';
-import {getBundledCssLink} from '../utils/helpers';
 
 const React = require('react');
 
@@ -639,10 +638,18 @@ export default class PopupModal extends React.Component {
             }
         `;
 
-        const cssLink = getBundledCssLink({appVersion: this.context.appVersion});
+        const stylesUrl = this.context.stylesUrl;
+        if (stylesUrl) {
+            return (
+                <>
+                    <link rel='stylesheet' href={stylesUrl} />
+                    <style dangerouslySetInnerHTML={{__html: styles}} />
+                    <meta name='viewport' content='width=device-width, initial-scale=1, maximum-scale=1' />
+                </>
+            );
+        }
         return (
             <>
-                <link rel='stylesheet' href={cssLink} />
                 <style dangerouslySetInnerHTML={{__html: styles}} />
                 <meta name='viewport' content='width=device-width, initial-scale=1, maximum-scale=1' />
             </>

--- a/src/index.js
+++ b/src/index.js
@@ -19,9 +19,8 @@ function getSiteData() {
     if (scriptTag) {
         const adminUrl = scriptTag.dataset.sodoSearch;
         const apiKey = scriptTag.dataset.key;
-        const appVersion = scriptTag.dataset.version;
         const stylesUrl = scriptTag.dataset.styles;
-        return {adminUrl, apiKey, appVersion, stylesUrl};
+        return {adminUrl, apiKey, stylesUrl};
     }
     return {};
 }
@@ -31,14 +30,13 @@ function setup() {
 }
 
 function init() {
-    const {adminUrl, apiKey, appVersion, stylesUrl} = getSiteData();
+    const {adminUrl, apiKey, stylesUrl} = getSiteData();
     const adminBaseUrl = (adminUrl || window.location.origin)?.replace(/\/+$/, '');
     setup();
     ReactDOM.render(
         <React.StrictMode>
             <App
                 adminUrl={adminBaseUrl} apiKey={apiKey}
-                appVersion={appVersion}
                 stylesUrl={stylesUrl}
             />
         </React.StrictMode>,

--- a/src/index.js
+++ b/src/index.js
@@ -20,7 +20,8 @@ function getSiteData() {
         const adminUrl = scriptTag.dataset.sodoSearch;
         const apiKey = scriptTag.dataset.key;
         const appVersion = scriptTag.dataset.version;
-        return {adminUrl, apiKey, appVersion};
+        const stylesUrl = scriptTag.dataset.styles;
+        return {adminUrl, apiKey, appVersion, stylesUrl};
     }
     return {};
 }
@@ -30,7 +31,7 @@ function setup() {
 }
 
 function init() {
-    const {adminUrl, apiKey, appVersion} = getSiteData();
+    const {adminUrl, apiKey, appVersion, stylesUrl} = getSiteData();
     const adminBaseUrl = (adminUrl || window.location.origin)?.replace(/\/+$/, '');
     setup();
     ReactDOM.render(
@@ -38,6 +39,7 @@ function init() {
             <App
                 adminUrl={adminBaseUrl} apiKey={apiKey}
                 appVersion={appVersion}
+                stylesUrl={stylesUrl}
             />
         </React.StrictMode>,
         document.getElementById(ROOT_DIV_ID)

--- a/src/utils/helpers.js
+++ b/src/utils/helpers.js
@@ -1,7 +1,0 @@
-export function getBundledCssLink({appVersion}) {
-    if (process.env.NODE_ENV === 'production' && appVersion) {
-        return `https://unpkg.com/@tryghost/sodo-search@~${appVersion}/umd/main.css`;
-    } else {
-        return 'http://localhost:3000/main.css';
-    }
-}


### PR DESCRIPTION
- the stylesheet link was hardcoded in the app previously except the version, which made it very hard to be configurable from upstream Ghost instance
- fetches css url from the data attribute on script instead which allows the url to be easily configured in Ghost